### PR TITLE
fix:allow workshop 3.0.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-ovos-workshop>=2.1.0,<3.0.0
+ovos-workshop>=2.1.0,<4.0.0
 ovos-utils<2.0.0
 ovos-bus-client<2.0.0
 ovos-plugin-manager


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated the version constraint for the `ovos-workshop` package to support a broader range of compatible versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->